### PR TITLE
環境変数を用いてdevとprodで挙動を分ける（lambda側）

### DIFF
--- a/components/Organisms/Contact.vue
+++ b/components/Organisms/Contact.vue
@@ -180,6 +180,7 @@ export default {
   cursor: pointer;
   &[disabled] {
     opacity: 0.7;
+    cursor: not-allowed;
   }
 }
 

--- a/lambda/submission-created.js
+++ b/lambda/submission-created.js
@@ -2,7 +2,6 @@ import querystring from 'querystring';
 import axios from 'axios';
 
 exports.handler = function(event, context, callback) {
-
   // NOTE:
   // production環境で、event はオブジェクト型で来ているが、event.body はString型だった。
   // Netlify側のログが出たり出なかったりしたため苦労したが、
@@ -15,7 +14,9 @@ exports.handler = function(event, context, callback) {
   // ローカルでのエミュレートに合わせ、Netlify 側でもビルドするようにした。
   // そうしないと axios も使えないし。
 
-  const token = process.env.IYU_FORM_NOTIFY_TOKEN_TEST && process.env.IYU_FORM_NOTIFY_TOKEN_PROD;
+  const token =
+    process.env.IYU_FORM_NOTIFY_TOKEN_TEST &&
+    process.env.IYU_FORM_NOTIFY_TOKEN_PROD;
   const params = process.env.IYU_FORM_NOTIFY_TOKEN_TEST
     ? querystring.parse(decodeURIComponent(event.body))
     : JSON.parse(event.body).payload.data;

--- a/lambda/submission-created.js
+++ b/lambda/submission-created.js
@@ -2,8 +2,6 @@ import querystring from 'querystring';
 import axios from 'axios';
 
 exports.handler = function(event, context, callback) {
-  // const token = process.env.IYU_FORM_NOTIFY_TOKEN_TEST // test
-  const token = process.env.IYU_FORM_NOTIFY_TOKEN_PROD; // production
 
   // NOTE:
   // production環境で、event はオブジェクト型で来ているが、event.body はString型だった。
@@ -17,9 +15,10 @@ exports.handler = function(event, context, callback) {
   // ローカルでのエミュレートに合わせ、Netlify 側でもビルドするようにした。
   // そうしないと axios も使えないし。
 
-  // todo: 環境変数でdevとprodを分ける
-  // const params = querystring.parse(decodeURIComponent(event.body)) // development
-  const params = JSON.parse(event.body).payload.data; // production
+  const token = process.env.IYU_FORM_NOTIFY_TOKEN_TEST && process.env.IYU_FORM_NOTIFY_TOKEN_PROD;
+  const params = process.env.IYU_FORM_NOTIFY_TOKEN_TEST
+    ? querystring.parse(decodeURIComponent(event.body))
+    : JSON.parse(event.body).payload.data;
 
   axios({
     method: 'post',

--- a/lambda/submission-created.js
+++ b/lambda/submission-created.js
@@ -15,7 +15,7 @@ exports.handler = function(event, context, callback) {
   // そうしないと axios も使えないし。
 
   const token =
-    process.env.IYU_FORM_NOTIFY_TOKEN_TEST &&
+    process.env.IYU_FORM_NOTIFY_TOKEN_TEST ||
     process.env.IYU_FORM_NOTIFY_TOKEN_PROD;
   const params = process.env.IYU_FORM_NOTIFY_TOKEN_TEST
     ? querystring.parse(decodeURIComponent(event.body))


### PR DESCRIPTION
- client側は時間かかりそうだったため後日
  - ビルド時のみ（サーバー側でJSが解釈されるときのみ）process.envを見て結果を変数かなにかに保持...
  - dotenvを使わないと辛いか